### PR TITLE
Disable window sounds

### DIFF
--- a/plugin/PluginWindowCardInfo.cs
+++ b/plugin/PluginWindowCardInfo.cs
@@ -55,6 +55,8 @@ namespace TriadBuddyPlugin
             {
                 Plugin.CurrentLocManager.LocalizationChanged += (_) => { hasCachedLocStrings = false; };
             }
+
+            DisableWindowSounds = true;
         }
 
         public void Dispose()

--- a/plugin/PluginWindowCardSearch.cs
+++ b/plugin/PluginWindowCardSearch.cs
@@ -94,6 +94,8 @@ namespace TriadBuddyPlugin
             {
                 Plugin.CurrentLocManager.LocalizationChanged += (_) => { hasCachedLocStrings = false; };
             }
+
+            DisableWindowSounds = true;
         }
 
         public void Dispose()

--- a/plugin/PluginWindowDeckEval.cs
+++ b/plugin/PluginWindowDeckEval.cs
@@ -61,6 +61,8 @@ namespace TriadBuddyPlugin
             {
                 Plugin.CurrentLocManager.LocalizationChanged += (_) => { hasCachedLocStrings = false; };
             }
+
+            DisableWindowSounds = true;
         }
 
         public void Dispose()

--- a/plugin/PluginWindowDeckSearch.cs
+++ b/plugin/PluginWindowDeckSearch.cs
@@ -50,6 +50,8 @@ namespace TriadBuddyPlugin
                 ImGuiWindowFlags.NoDocking |
                 ImGuiWindowFlags.NoFocusOnAppearing |
                 ImGuiWindowFlags.NoNav;
+
+            DisableWindowSounds = true;
         }
 
         public void Dispose()


### PR DESCRIPTION
Window Sound effects have been a thing in Dalamud for several API bumps now and TriadBuddy's windows don't have them disabled, wich causes them to play twice since they open with normal game windows.
This PR just disables them.